### PR TITLE
Add minimal project documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+- Initial repository scaffolding.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,29 @@
+# Contributing to Bahri
+
+Thanks for your interest in contributing! This project is in its early
+stages, so processes are intentionally lightweight.
+
+## Workflow
+
+1. Fork or branch from `master`.
+2. Use a descriptive branch name (e.g. `feature/<topic>` or `fix/<topic>`).
+3. Make focused commits with clear messages.
+4. Open a pull request describing **what** changed and **why**.
+
+## Commit messages
+
+- Use the imperative mood ("Add X", not "Added X").
+- Keep the subject line under ~72 characters.
+- Add a body when context isn't obvious from the diff.
+
+## Development setup
+
+TBD — instructions will be added once the project's tech stack is chosen.
+
+## Tests
+
+TBD — a test command will be documented once tests exist.
+
+## Code of Conduct
+
+Be respectful. A formal Code of Conduct will be added later.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # Bahri
-Under construction. Please return later.
+
+> Status: Under construction.
+
+A brief description of Bahri will go here once the project's scope is defined.
+
+## Getting Started
+
+Setup and usage instructions will be added once the tech stack is chosen.
+
+## Contributing
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).
+
+## Changelog
+
+See [CHANGELOG.md](./CHANGELOG.md).
+
+## License
+
+TBD.


### PR DESCRIPTION
Expand the placeholder README with standard sections (Status, Getting
Started, Contributing, Changelog, License) and add a Keep-a-Changelog
formatted CHANGELOG.md and a lightweight CONTRIBUTING.md. Setup, test
commands, and license are left as TBD until the project's tech stack
and license are chosen.